### PR TITLE
Fix typo in security-privacy.mdx

### DIFF
--- a/deployment/security-privacy.mdx
+++ b/deployment/security-privacy.mdx
@@ -14,7 +14,7 @@ be decrypted by the intended recipient. Even relay servers that facilitate
 connections between endpoints cannot read the data being transmitted.
 
 End-to-end encryption is achieved using modern cryptographic algorithms and protocols,
-ensuring that data remains confidential and secure during transit. By defaul;t,
+ensuring that data remains confidential and secure during transit. By default,
 iroh uses Ed25519 keys for endpoint identities and encryption. If you require
 different cryptographic algorithms, you can configure iroh to use them during
 endpoint creation. 


### PR DESCRIPTION
Corrected a typo in the word 'default'.

Just spotted while perusing the docs, leaving a drive-by PR.