### PR TITLE
Fix stale discovery docs links

### DIFF
--- a/about/faq.mdx
+++ b/about/faq.mdx
@@ -81,7 +81,7 @@ For most usage, using the services that are enabled by default in the `iroh::End
 Discovery helps iroh find ways to connect to a specific Endpoint ID.
 The Endpoint ID on its own can only be used to identify if you're talking to the right recipient, but doesn't tell how to address the recipient on its own.
 Via configured discovery mechanisms, iroh resolves an Endpoint ID to IP addresses and relay URLs that help to actually attempt a connection.
-For more information on available discovery mechanisms, take a look at the [discovery module](https://docs.rs/iroh/latest/iroh/discovery/index.html).
+For more information on available discovery mechanisms, take a look at the [address lookup module](https://docs.rs/iroh/latest/iroh/address_lookup/index.html).
 It's also possible to combine multiple discovery mechanisms at once, or write your own.
 We think it's particularly helpful to write application-specific discovery mechanisms that are tailored to an application's need.
 

--- a/concepts/discovery.mdx
+++ b/concepts/discovery.mdx
@@ -6,7 +6,7 @@ title: "Discovery"
 Discovery is the glue that connects an [Endpoint](/concepts/endpoints#endpoint-identifiers) to something we can dial. Discovery services resolve EndpointIDs to either a home Relay URL or direct-dialing information. 
 
 <Note>
-  More details on discovery in the discovery module [documentation](https://docs.rs/iroh/latest/iroh/discovery/index.html)
+  More details on discovery in the address lookup module [documentation](https://docs.rs/iroh/latest/iroh/address_lookup/index.html)
 </Note>
 
 Endpoint discovery is an automated system for an [Endpoint](/concepts/endpoints) to retrieve addressing information. Each iroh endpoint will automatically publish their own addressing information with configured discovery services. Usually this means publishing which [Home Relay](/concepts/relays) an endpoint is findable at, but they could also publish their direct addresses.


### PR DESCRIPTION
Fixes #50. `iroh::discovery` was renamed to `iroh::address_lookup` in n0-computer/iroh#3853, so the old docs.rs URL now returns 404. Updated stale docs.rs links in: - `/concepts/discovery` - `/about/faq` New target: https://docs.rs/iroh/latest/iroh/address_lookup/index.html