### PR TITLE
update bluetooth documentation

### DIFF
--- a/transports/bluetooth.mdx
+++ b/transports/bluetooth.mdx
@@ -2,25 +2,57 @@
 title: "Bluetooth (BLE)"
 ---
 
-Bluetooth support is powered by [blew](https://github.com/mcginty/blew), an open source BLE (Bluetooth Low Energy) Rust library focused on enabling peer-to-peer applications.
+The [iroh-ble-transport](https://github.com/mcginty/iroh-ble-transport) crate
+routes iroh over BLE (Bluetooth Low Energy) to allow for P2P connectivity
+without the internet.
+
+iroh-ble-transport supports macOS, iOS, Android, and Linux. In the future, it
+could support other platforms as well like Windows or Espressif (ESP32 family).
 
 <Warning>
-blew is in alpha state and is subject to change without backwards-compatibility until otherwise noted.
+Both iroh's custom transport API and this crate are experimental. Expect breaking changes.
 </Warning>
 
-blew implements both Central and Peripheral modes, with support for macOS, iOS, Android, and Linux. It is async-only and requires a Tokio runtime.
+iroh-ble-transport is open source under the [AGPL
+license](https://www.gnu.org/licenses/agpl-3.0.en.html). Commercial licenses are
+available for use cases where the AGPL is not suitable. Contact the [number0
+team](https://cal.com/team/number-0/iroh-services?overlayCalendar=true) or
+[me@jakebot.org](mailto:me@jakebot.org) for details.
 
-blew is open source under the [AGPL license](https://www.gnu.org/licenses/agpl-3.0.en.html). Commercial licenses are available for use cases where the AGPL is not suitable. Contact the [number0 team](https://cal.com/team/number-0/iroh-services?overlayCalendar=true) or [me@jakebot.org](mailto:me@jakebot.org) for details.
+## Performance notes
 
-## Custom transport API
-
-The custom transport API lets anyone implement new transports by implementing a
-set of traits for low-level packet sending and receiving. Each transport defines
-its own address type and serialization format.
+Bluetooth connections on mobile devices typically max out at about ~3-5
+connections per device. Per connection, you can expect about 100kbps in decent
+conditions, but it's very dependent on the surrounding radio environment
+and devices that you're using.
 
 ## Usage
 
+```rust
+use iroh::endpoint::presets;
+use iroh::{Endpoint, SecretKey};
+use iroh_ble_transport::BleTransport;
+let secret_key = SecretKey::generate();
+
+let ble = BleTransport::builder().build(secret_key.public()).await?;
+
+let _endpoint = Endpoint::builder(presets::N0DisableRelay)
+    .hooks(ble.dedup_hook())
+    .add_custom_transport(ble.as_custom_transport())
+    .address_lookup(ble.address_lookup())
+    .secret_key(secret_key.clone())
+    .clear_ip_transports()
+    .bind()
+    .await?;
+```
+
+## Feature flag
 
 Custom transport support requires the `unstable-custom-transports` feature flag.
-The API is unstable and subject to change. See [PR
-#3845](https://github.com/n0-computer/iroh/pull/3845) for background.
+The API is unstable and subject to change. See
+[#3845](https://github.com/n0-computer/iroh/pull/3845) for background.
+
+```toml
+[dependencies]
+iroh = { version = "*", features = ["unstable-custom-transports"] }
+```


### PR DESCRIPTION
Changed link to `iroh-ble-transport` instead of `blew` and added a minimal usage example.