### PR TITLE
Extend metrics retention to 7d free / 30d pro

### DIFF
--- a/iroh-services/billing/index.mdx
+++ b/iroh-services/billing/index.mdx
@@ -10,7 +10,7 @@ Iroh Services offers plans to fit your needs, from free tiers for experimentatio
 | | **Free** | **Pro** | **Enterprise** |
 |---|---|---|---|
 | **Relays** | Shared public relays | Managed dedicated relays | Custom relay configurations |
-| **Metrics** | 1 day retention | 7 day retention | Custom retention & SLAs |
+| **Metrics** | 7 day retention | 30 day retention | Custom retention & SLAs |
 | **Net Diagnostics** | Community support | Priority support tickets | Guaranteed SLA response times |
 | **Support** | Discord | Email & Discord | Dedicated support & professional services |
 


### PR DESCRIPTION
Updates the billing overview plan table to match the metrics retention bump.

`iroh-services/billing/index.mdx`:
- **Free**: 1 day retention → **7 day retention**
- **Pro**: 7 day retention → **30 day retention**
- Enterprise: unchanged (Custom retention & SLAs)

The other retention mentions in the docs (`metrics/how-it-works.mdx`, `metrics/endpoint.mdx`) are generic and link out to the pricing page, so they don't hardcode day-counts and need no change.

Mirrors n0-computer/svc#870 (closes n0-computer/svc#867) and n0-computer/iroh.computer#460.
