### PR TITLE
Add zedra to example applications

### DIFF
--- a/examples.mdx
+++ b/examples.mdx
@@ -78,4 +78,11 @@ A multiplayer extension for Godot based on iroh.
   >
 Raspberry Pi and Pi Pico GPIO Remote control
 </Card>
+  <Card
+    title="zedra"
+    icon="code"
+    href="https://github.com/tanlethanh/zedra"
+  >
+A mobile code editor for iOS and Android that tunnels to your desktop over an encrypted iroh P2P connection, letting you read code, view changes, and run AI agents from your phone.
+</Card>
 </Columns>


### PR DESCRIPTION
Adds [zedra](https://github.com/tanlethanh/zedra) — a mobile code editor for iOS and Android that tunnels to a desktop over an encrypted iroh P2P connection — to the Applications section of the examples page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)