### PR TITLE
Fix Rust custom relay example

### DIFF
--- a/snippets/relay-endpoint-config.mdx
+++ b/snippets/relay-endpoint-config.mdx
@@ -1,16 +1,18 @@
 <CodeGroup>
 
 ```rust Rust
-use iroh::Endpoint;
-use iroh::relay::RelayUrl;
+use iroh::{Endpoint, RelayMap, RelayMode, RelayUrl, endpoint::presets};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let relay_url1: RelayUrl = "YOUR_RELAY_URL_US".parse()?;
     let relay_url2: RelayUrl = "YOUR_RELAY_URL_EU".parse()?;
 
-    let endpoint = Endpoint::builder()
-        .relay_mode(iroh::endpoint::RelayMode::Custom(vec![relay_url1, relay_url2]))
+    let endpoint = Endpoint::builder(presets::N0)
+        .relay_mode(RelayMode::Custom(RelayMap::from_iter([
+            relay_url1,
+            relay_url2,
+        ])))
         .bind()
         .await?;
 


### PR DESCRIPTION
Fixes #53.

The Rust tab of the custom relay snippet (used by the dedicated infrastructure page) had three problems against iroh 1.0.0-rc.1:

- `RelayMode::Custom` takes a `RelayMap`, not a `Vec<RelayUrl>` (the bug reported in #53). Now uses `RelayMap::from_iter`, which is implemented for `RelayUrl` iterators.
- `use iroh::relay::RelayUrl` is not a valid path; `RelayUrl` is exported at the crate root.
- `Endpoint::builder()` now requires a preset argument; passes `presets::N0`, matching the other language tabs which combine `preset_n0()` with a `relay_mode` override.

Verified the corrected example with `cargo check` against `iroh@1.0.0-rc.1`. The Python, Swift, and Kotlin tabs use the bindings' `RelayMode.customFromUrls(...)` API and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)