### PR TITLE
update from rc.1 to 1.0

### DIFF
--- a/connect-two-endpoints.mdx
+++ b/connect-two-endpoints.mdx
@@ -32,7 +32,7 @@ pip install iroh
 swift package init --type executable --name ping-pong
 cd ping-pong
 # add to Package.swift dependencies:
-#   .package(url: "https://github.com/n0-computer/iroh-ffi", from: "1.0.0-rc.0")
+#   .package(url: "https://github.com/n0-computer/iroh-ffi", from: "1.0.0")
 # and to your target dependencies:
 #   .product(name: "IrohLib", package: "iroh-ffi")
 # work in Sources/ping-pong/main.swift
@@ -40,7 +40,7 @@ cd ping-pong
 
 ```bash Kotlin
 # scaffold a Gradle project, then add the iroh dependency:
-#   dependencies { implementation("computer.iroh:iroh:1.0.0-rc.0") }
+#   dependencies { implementation("computer.iroh:iroh:1.0.0") }
 # (Maven Central — requires mavenCentral() in your repositories block)
 # work in a Main.kt with `fun main(...)`
 ```

--- a/connecting/dht-address-lookup.mdx
+++ b/connecting/dht-address-lookup.mdx
@@ -17,8 +17,8 @@ crate, which you add alongside `iroh`.
 
 ```toml
 [dependencies]
-iroh = "1.0.0-rc.1"
-iroh-mainline-address-lookup = "0.3"
+iroh = "1"
+iroh-mainline-address-lookup = "0.4"
 ```
 
 Add the `DhtAddressLookup` to the endpoint with `Endpoint::builder`. You can run it

--- a/connecting/local-address-lookup.mdx
+++ b/connecting/local-address-lookup.mdx
@@ -20,8 +20,8 @@ crate, which you add alongside `iroh`.
 
 ```toml
 [dependencies]
-iroh = "1.0.0-rc.1"
-iroh-mdns-address-lookup = "0.3"
+iroh = "1"
+iroh-mdns-address-lookup = "0.4"
 ```
 
 Add the `MdnsAddressLookup` to the endpoint with `Endpoint::builder`. We run it next to the default DNS address lookup, so connections still work when the two endpoints are not on the same local network.

--- a/languages/kotlin.mdx
+++ b/languages/kotlin.mdx
@@ -31,7 +31,7 @@ repositories {
 }
 
 dependencies {
-    implementation("computer.iroh:iroh:1.0.0-rc.1")
+    implementation("computer.iroh:iroh:1.0.0")
 }
 ```
 

--- a/languages/wasm-browser.mdx
+++ b/languages/wasm-browser.mdx
@@ -35,7 +35,7 @@ node is involved in the connection.
 ### `iroh` crate features
 
 You need to disable iroh's default features for the Wasm build to succeed.
-To do so, depend on iroh via `iroh = { version = "1.0.0-rc.1", default-features = false }`.
+To do so, depend on iroh via `iroh = { version = "1", default-features = false }`.
 This drops the `metrics` feature, so iroh no longer tracks metrics locally.
 
 ### npm package


### PR DESCRIPTION
updates version references:
* `iroh` from `1.0.0-rc.1` to `1.0`
* `iroh-mainline-address-lookup` from `0.3` to `0.4`
* `iroh-mdns-address-lookup` from `0.3` to `0.4`
* kotlin and swift bindings from `1.0.0-rc.1` to `1.0.0`

should only be merged once all of the above is released