### PR TITLE
quickstart: move API key to final step, frame around metrics

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -5,30 +5,20 @@ description: "Connect two iroh endpoints in five minutes"
 
 In five minutes you'll have two iroh endpoints connecting over the [iroh-ping](https://github.com/n0-computer/iroh-ping) protocol. Clone the repo, run the included quickstart example as a receiver in one terminal and a sender in another, and watch the round-trip time print.
 
-### 1. Set your API key
-
-If you want to see your metrics and verify connectivity, get an API key from your project's **Settings → API Keys** tab and export it as an environment variable. See [API Keys](/iroh-services/access) for the full walkthrough.
-
-```bash
-export IROH_SERVICES_API_SECRET=<your-api-key>
-```
-
-The example will pick up the key automatically. This step is optional, skip this step if you just want to see iroh-ping work.
-
-### 2. Install Rust
+### 1. Install Rust
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-### 3. Clone iroh-ping
+### 2. Clone iroh-ping
 
 ```bash
 git clone https://github.com/n0-computer/iroh-ping
 cd iroh-ping
 ```
 
-### 4. Run the receiver
+### 3. Run the receiver
 
 ```bash
 cargo run --example quickstart receiver
@@ -36,7 +26,7 @@ cargo run --example quickstart receiver
 
 The receiver prints a ticket. Copy it.
 
-### 5. Run the sender
+### 4. Run the sender
 
 In another terminal:
 
@@ -45,6 +35,16 @@ cargo run --example quickstart sender <TICKET>
 ```
 
 Replace `<TICKET>` with the ticket from the receiver. The sender will print the round-trip time once the connection succeeds.
+
+### 5. See your metrics (optional)
+
+Now that ping is working, hook the example up to Iroh Services to watch connectivity metrics like direct data rate. Get an API key from your project's **Settings → API Keys** tab, export it, and rerun the example:
+
+```bash
+export IROH_SERVICES_API_SECRET=<your-api-key>
+```
+
+The example picks up the key automatically and starts reporting metrics. See [API Keys](/iroh-services/access) for the full walkthrough, or [View metrics](/iroh-services/quickstart) to read the dashboard.
 
 ## Next steps
 


### PR DESCRIPTION
Someone flagged that leading the quickstart with **"1. Set your API key"** reads as too sales-y — it forces signup before the reader runs anything.

Reordered so iroh-ping runs first (steps 1–4: Install Rust → Clone → Receiver → Sender), then the API key returns as an optional final step, **"5. See your metrics (optional)"**, framed around reporting connectivity metrics to Iroh Services after ping already works.

Note: the page has 5 steps total, so the API key lands at step 5 (the last), not 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)