### PR TITLE
Fix broken iroh-automerge link in protocols page

### DIFF
--- a/concepts/protocols.mdx
+++ b/concepts/protocols.mdx
@@ -34,7 +34,7 @@ gives you endpoints and connections. From there, you choose:
 - [`iroh-blobs`](/protocols/blobs) - Content-addressed blob storage and transfer
 - [`iroh-docs`](/protocols/documents) - Collaborative key-value documents with CRDTs
 - [`iroh-gossip`](/connecting/gossip) - Topic-based message broadcasting in swarms
-- [`iroh-automerge`](https://github.com/n0-computer/iroh-experiments/tree/main/iroh-automerge) - Automerge document sync (experimental)
+- [`iroh-automerge`](https://github.com/n0-computer/iroh-examples/tree/main/iroh-automerge) - Automerge document sync (experimental)
 
 **Build your own** - Create custom protocols using:
 - Raw QUIC streams via iroh's connection API (most common approach)


### PR DESCRIPTION
The `iroh-automerge` link on `/concepts/protocols` pointed to the `iroh-experiments` repo, which 404s. The crate now lives in `iroh-examples`.

- Before: `https://github.com/n0-computer/iroh-experiments/tree/main/iroh-automerge` (404)
- After: `https://github.com/n0-computer/iroh-examples/tree/main/iroh-automerge` (200)

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)