### PR TITLE
feat: Replace mermaid with svg

### DIFF
--- a/concepts/nat-traversal.mdx
+++ b/concepts/nat-traversal.mdx
@@ -52,6 +52,10 @@ Both peers try to connect to each other **at the same time**. When peer A sends 
 
 Because both mappings are now established and both firewalls expect traffic from each other, the packets get through and a direct connection is formed.
 
+<Frame>
+  <img src="https://www.iroh.computer/animations/hole-punching.svg" alt="Alice and Bob, each behind a home router, first reach each other through the relay, then both send packets simultaneously to punch through their NATs; once the direct path is validated the relay path falls away and traffic flows directly" style={{ width: '100%' }} />
+</Frame>
+
 ### 4. Fallback to Relay
 
 If NAT traversal fails (some networks use particularly strict configurations), iroh automatically falls back to routing traffic through the relay server. This ensures connections always work, even if they can't be direct.

--- a/connecting/dht-address-lookup.mdx
+++ b/connecting/dht-address-lookup.mdx
@@ -12,7 +12,7 @@ dependency on a hosted server: any endpoint can publish and resolve without a
 central party, at the cost of slower lookups than DNS.
 
 <Frame>
-  <img src="https://www.iroh.computer/animations/publish-relay-dht.svg" alt="Bob publishes his signed record to several random nodes of the Mainline DHT; Alice resolves it by querying several random nodes" style={{ width: '100%' }} />
+  <img src="https://www.iroh.computer/animations/publish-relay-dht.svg" alt="Bob publishes his signed record to several nodes of the Mainline DHT; Alice resolves it by querying several nodes" style={{ width: '100%' }} />
 </Frame>
 
 DHT address lookup is not enabled by default. It lives in the separate

--- a/connecting/dht-address-lookup.mdx
+++ b/connecting/dht-address-lookup.mdx
@@ -11,6 +11,10 @@ while DHT address lookup puts them on the BitTorrent Mainline DHT. That removes 
 dependency on a hosted server: any endpoint can publish and resolve without a
 central party, at the cost of slower lookups than DNS.
 
+<Frame>
+  <img src="https://www.iroh.computer/animations/publish-relay-dht.svg" alt="Bob publishes his signed record to several random nodes of the Mainline DHT; Alice resolves it by querying several random nodes" style={{ width: '100%' }} />
+</Frame>
+
 DHT address lookup is not enabled by default. It lives in the separate
 [`iroh-mainline-address-lookup`](https://crates.io/crates/iroh-mainline-address-lookup)
 crate, which you add alongside `iroh`.

--- a/connecting/dns-address-lookup.mdx
+++ b/connecting/dns-address-lookup.mdx
@@ -8,6 +8,10 @@ An endpoint publishes a signed record that maps its `EndpointId` to its home rel
 URL (and optionally its direct addresses), and resolves the same kind of record for
 endpoints it wants to dial.
 
+<Frame>
+  <img src="https://www.iroh.computer/animations/publish-relay.svg" alt="Bob publishes a signed DNS record with his home relay to dns.iroh.link via an HTTPS PUT; Alice resolves it with a DNS lookup" style={{ width: '100%' }} />
+</Frame>
+
 ## How records are published and resolved
 
 Each endpoint creates a set of records with its addressing information, and puts it into a signed [Pkarr](https://pkarr.org) packet. The packet is signed by the endpoint's secret key.

--- a/connecting/local-address-lookup.mdx
+++ b/connecting/local-address-lookup.mdx
@@ -12,6 +12,10 @@ work. This can be a Wi-Fi network, an Ethernet network, or even a mobile
 hotspot. mDNS is not designed to work over the internet or across different
 networks.
 
+<Frame>
+  <img src="https://www.iroh.computer/animations/mdns-address-lookup.svg" alt="Three devices on the same network — an iPhone, an Android phone and an embedded device — behind one router; each multicasts an mDNS announcement of its key and local address, and every device's known-peers list grows as the announcements arrive" style={{ width: '100%' }} />
+</Frame>
+
 ## Usage
 
 mDNS address lookup is not enabled by default. It lives in the separate

--- a/what-is-iroh.mdx
+++ b/what-is-iroh.mdx
@@ -158,21 +158,9 @@ just needs to learn the other's local address. See
 
 An iroh application is a stack of small layers, each with one job:
 
-```mermaid
-flowchart TB
-    app["Your application"]
-    protocols["Protocols<br/>blobs, docs, gossip, yours"]
-    router["Router<br/>dispatches connections by ALPN"]
-    endpoint["Endpoint<br/>identity, address lookup, NAT, relay"]
-    quic["QUIC + TLS 1.3"]
-    transport["Transport<br/>UDP default, Tor, Nym, BLE"]
-
-    app --- protocols
-    protocols --- router
-    router --- endpoint
-    endpoint --- quic
-    quic --- transport
-```
+<Frame>
+  <img src="https://www.iroh.computer/animations/layer-stack.svg" alt="An iroh application as a stack of layers inside your application: Protocols (blobs, gossip, yours), Router (dispatches connections by ALPN), Endpoint (identity, address lookup, NAT, relay), QUIC + TLS 1.3 (encryption, auth, stream mux), and Transport (UDP and relay by default, swappable) — with Ethernet, Wi-Fi, and Tor as interchangeable transports underneath" style={{ width: '100%' }} />
+</Frame>
 
 - **Transport** carries encrypted bytes between machines. UDP is the default;
   you can swap in [Tor](/transports/tor), [Nym](/transports/nym), or

--- a/what-is-iroh.mdx
+++ b/what-is-iroh.mdx
@@ -122,7 +122,7 @@ exact same signed record using the
 [DHT address lookup](/connecting/dht-address-lookup).
 
 <Frame>
-  <img src="https://www.iroh.computer/animations/publish-relay-dht.svg" alt="Bob publishes his signed record to several random nodes of the Mainline DHT; Alice resolves it by querying several random nodes" style={{ width: '100%' }} />
+  <img src="https://www.iroh.computer/animations/publish-relay-dht.svg" alt="Bob publishes his signed record to several nodes of the Mainline DHT; Alice resolves it by querying several nodes" style={{ width: '100%' }} />
 </Frame>
 
 ### Direct connections


### PR DESCRIPTION
Replace mermaid with svg.

New svg is https://www.iroh.computer/animations/layer-stack.svg

Wire up the svgs in the individual address lookup pages as well.