### PR TITLE
docs: move net diagnostics integration into the tutorial

### DIFF
--- a/iroh-services/net-diagnostics/usage.mdx
+++ b/iroh-services/net-diagnostics/usage.mdx
@@ -82,6 +82,26 @@ async fn setup_net_diagnostics(endpoint: &Endpoint) -> Result<Router> {
 }
 ```
 
+### 4. Register on your existing router
+
+The example above spawns a router that serves only `CLIENT_HOST_ALPN`. Most
+applications already run a `Router` with their own protocols. Register the
+handler on that same builder rather than spawning a second router:
+
+```rust
+use iroh::protocol::Router;
+use iroh_services::{ClientHost, CLIENT_HOST_ALPN};
+
+let router = Router::builder(endpoint.clone())
+    .accept(MY_PROTOCOL_ALPN, my_protocol) // your application's protocols
+    .accept(CLIENT_HOST_ALPN, ClientHost::new(&endpoint)) // add this line
+    .spawn();
+```
+
+Calling `.spawn()` finalizes the router's set of protocols, so the
+`.accept(CLIENT_HOST_ALPN, ...)` call has to come before it. Register every
+ALPN your endpoint serves on the one router you spawn for that endpoint.
+
 ## Understanding Reports
 
 ### NAT Types
@@ -107,3 +127,10 @@ The capability grant (`NetDiagnosticsCap::GetAny`) authorizes the platform to
 request diagnostics from your endpoint. Without this grant, the **Run
 Diagnostics** button will be disabled in the dashboard even if the endpoint is
 online.
+
+If the button is enabled but the report never arrives, your endpoint is not
+accepting `CLIENT_HOST_ALPN`. The grant only tells the platform that it may dial
+back; the endpoint still has to answer that dial with a `ClientHost`. Confirm
+that you call `.accept(CLIENT_HOST_ALPN, ClientHost::new(&endpoint))` on the
+router you spawn for this endpoint, that the call happens before `.spawn()`, and
+that the router stays alive for as long as the endpoint does.


### PR DESCRIPTION
Reorganizes the net diagnostics docs so the integration code lives in the "Diagnose a connectivity issue" tutorial, where readers are already working, instead of on a separate page a click away.

- **quickstart.mdx** (tutorial): the "Integrate into your app" section now carries the actual code — `cargo add`, the client setup with the capability grant, and registering `ClientHost` on an existing router (with the note that `.accept(CLIENT_HOST_ALPN, ...)` must come before `.spawn()`).
- **usage.mdx** (Network Diagnostics): becomes a reference for reading reports and troubleshooting. It keeps "Understanding Reports" and gains a troubleshooting entry for the case where the grant is present and the endpoint is online but the report never arrives, because nothing accepts `CLIENT_HOST_ALPN`.

No nav or redirect changes; both pages stay where they are and cross-link.