### PR TITLE
Add a dedicated contact form

### DIFF
--- a/about/release-policy.mdx
+++ b/about/release-policy.mdx
@@ -48,9 +48,9 @@ The wire protocol must also remain compatible across minor versions within the s
 
 | Release | Full Support | Maintenance Mode | Extended Support |
 |---------|--------------|------------------|-------------------|
-| Major | 1 year | 1–3 years after release | [Contact us](mailto:support@iroh.computer) |
-| Minor | 3 months | 3 months – 1 year after release | [Contact us](mailto:support@iroh.computer) |
-| Canary | N/A | N/A | [Contact us](mailto:support@iroh.computer) |
+| Major | 1 year | 1–3 years after release | [Contact us](/contact) |
+| Minor | 3 months | 3 months – 1 year after release | [Contact us](/contact) |
+| Canary | N/A | N/A | [Contact us](/contact) |
 | Experimental | N/A | N/A | N/A |
 | Release Candidate | N/A | N/A | N/A |
 

--- a/compatibility.mdx
+++ b/compatibility.mdx
@@ -29,7 +29,7 @@ iroh is regularly tested on a wide range of hardware, from servers to microcontr
 | Raspberry Pi | Fully supported |
 | ESP32 | Supported with caveats |
 
-For hardware you don't see here, or to integrate your custom hardware into our testing frameworks on every iroh release, [contact us.](mailto:support@iroh.computer) 
+For hardware you don't see here, or to integrate your custom hardware into our testing frameworks on every iroh release, [contact us.](/contact) 
 
 
 ### ESP32 Resource Requirements
@@ -39,7 +39,7 @@ We have built a version of iroh which has been tested on ESP32 with very constra
 - **4 MiB Flash / 4 MiB RAM**: working, though 4 MiB flash is right at the limit
 - **4 MiB Flash / 2 MiB RAM**: also works in testing
 
-To use ESP32 in production, [contact us for licensing & support.](mailto:support@iroh.computer)
+To use ESP32 in production, [contact us for licensing & support.](/contact)
 
 ## Network Transports
 
@@ -52,4 +52,4 @@ To use ESP32 in production, [contact us for licensing & support.](mailto:support
 | Tor | [Yes](/transports/tor) |
 | Nym | [Yes](/transports/nym) |
 
-If there is a transport you need that is not listed, [contact us.](mailto:support@iroh.computer)
+If there is a transport you need that is not listed, [contact us.](/contact)

--- a/contact.mdx
+++ b/contact.mdx
@@ -1,0 +1,26 @@
+---
+title: "Contact us"
+description: "Ways to reach the n0 / iroh team — email, scheduling a call, and Discord."
+---
+
+Want to talk about licensing, custom hardware, a transport, capacity, a plan, or anything else? Here are the best ways to reach us.
+
+<Columns cols={2}>
+  <Card title="Email" icon="envelope">
+  We read every message — copy our address with the icon in the corner:
+
+  ```
+  support@iroh.computer
+  ```
+  </Card>
+  <Card title="Schedule a call" icon="calendar" href="https://cal.com/team/number-0/iroh-services">
+  Book a meeting with the team to talk through your use case, integration, or production needs.
+  </Card>
+  <Card title="Discord" icon="discord" href="https://iroh.computer/discord">
+  The community and the n0 team are active and happy to answer questions.
+  </Card>
+</Columns>
+
+<Note>
+Already running iroh and hitting a problem? Head to [Support](/iroh-services/support) for Discord, support tickets, and SLAs.
+</Note>

--- a/deployment/metrics.mdx
+++ b/deployment/metrics.mdx
@@ -31,5 +31,5 @@ metrics.pings_recv.inc();
 ## Exporting metrics
 
 - *Prometheus*: The `iroh-metrics` crate supports exporting metrics to Prometheus.
-- *iroh services*: [Contact us](mailto:support@iroh.computer) if you are interested in custom metrics hosting without prometheus.
+- *iroh services*: [Contact us](/contact) if you are interested in custom metrics hosting without prometheus.
 

--- a/iroh-services/billing/faq.mdx
+++ b/iroh-services/billing/faq.mdx
@@ -27,7 +27,7 @@ issue isn't resolved, your project may be downgraded to the Free plan.
 Relays are billed based on hourly usage, so you'll only be charged for the hours
 you used. For example, if you cancel after 10 hours of relay usage in a month,
 you'll only be billed for those 10 hours. If you have any
-questions about your bill or refunds, please contact us at [support@iroh.computer](mailto:support@iroh.computer).
+questions about your bill or refunds, please [contact us](/contact).
 
 ## How do spend caps work?
 
@@ -48,4 +48,4 @@ may or may not be added at checkout based on your billing address and your local
 
 ## I have a billing question not listed here
 
-Reach out to us at [support@iroh.computer](mailto:support@iroh.computer).
+Reach out to us — see [Contact us](/contact) for all the ways to get in touch.

--- a/iroh-services/metrics/endpoint.mdx
+++ b/iroh-services/metrics/endpoint.mdx
@@ -32,7 +32,7 @@ long-term performance optimization and troubleshooting.
 Please refer to the [pricing page](https://iroh.computer/pricing?utm_source=docs&utm_content=endpoint-metrics) for more details on plan features
 and benefits. 
 
-[Contact us](mailto:support@iroh.computer) if you have any questions about upgrading your plan.
+[Contact us](/contact) if you have any questions about upgrading your plan.
 
 ## Glossary
 

--- a/iroh-services/metrics/how-it-works.mdx
+++ b/iroh-services/metrics/how-it-works.mdx
@@ -36,4 +36,4 @@ Endpoint level metrics are only available on Enterprise plans. For projects on
 these plans, the amount of endpoint-level raw data retained is calculated on
 your purchased metrics package.  There is a rolling lookback window for metrics
 retention that is based on your metrics package. [Contact
-us](mailto:support@iroh.computer) if you need more custom support.
+us](/contact) if you need more custom support.

--- a/iroh-services/relays/managed.mdx
+++ b/iroh-services/relays/managed.mdx
@@ -14,8 +14,8 @@ Managed relays are dedicated relay servers provisioned through the Iroh Services
 - **Isolation**: your traffic only; no noisy neighbors
 - **Version locking**: pin to a specific iroh version or run blue/green deployments
 - **Multi-region & multi-cloud**: deploy across regions and providers for resilience
-- **On-prem**: available on Enterprise plans; [contact us](mailto:support@iroh.computer)
-- **Custom SLAs**: [contact us](mailto:support@iroh.computer)
+- **On-prem**: available on Enterprise plans; [contact us](/contact)
+- **Custom SLAs**: [contact us](/contact)
 
 ## Deploy a relay
 
@@ -84,8 +84,8 @@ just don't require your API key to connect.
 
 For production, deploy at least two relays in different geographic regions. If one relay becomes unreachable, iroh automatically falls back to the next one in your list, so your peers will still find each other.
 
-Each relay handles up to 60,000 concurrent connections. For larger deployments, [contact us](mailto:support@iroh.computer) to increase relay capacity.
+Each relay handles up to 60,000 concurrent connections. For larger deployments, [contact us](/contact) to increase relay capacity.
 
 ## Support
 
-Relay status and metrics are available in your project dashboard under **Relays**. On the Pro plan, we offer priority support. [Contact us](mailto:support@iroh.computer) for Enterprise SLAs.
+Relay status and metrics are available in your project dashboard under **Relays**. On the Pro plan, we offer priority support. [Contact us](/contact) for Enterprise SLAs.

--- a/iroh-services/support.mdx
+++ b/iroh-services/support.mdx
@@ -9,7 +9,7 @@ If you're running into issues, the best place to reach out is on [discord](https
 
 ## Support Tickets
 
-On the **Pro** and **Enterprise** plans, you can open support tickets by emailing [support@iroh.computer](mailto:support@iroh.computer). Our team will triage and respond to your issue directly.
+On the **Pro** and **Enterprise** plans, you can open support tickets by emailing **support@iroh.computer**. Our team will triage and respond to your issue directly.
 
 ### SLA Response Times
 

--- a/languages/index.mdx
+++ b/languages/index.mdx
@@ -59,7 +59,7 @@ While it's easy to get a first version working, **ongoing maintenance and
 testing is the hard part**. iroh is under active development, and keeping
 wrappers up to date with new releases, testing across platforms, and handling
 edge cases takes sustained effort. The [number0](https://n0.computer) team runs
-a testing lab for this purpose. If you need help, [schedule a meeting](https://cal.com/team/number-0/iroh-services) or [contact us](mailto:support@iroh.computer).
+a testing lab for this purpose. If you need help, [schedule a meeting](https://cal.com/team/number-0/iroh-services) or [contact us](/contact).
 
 ## WebAssembly and browsers
 


### PR DESCRIPTION
I am a bit unclear about when we want to use this. support@iroh.computer sounds like support, not first contact situations. Also, are there cases where we don't want the cal.com link at all?