### PR TITLE
docs(languages): add C bindings via iroh-c-ffi

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -26,6 +26,7 @@
               "languages/swift",
               "languages/kotlin",
               "languages/javascript",
+              "languages/c",
               "languages/go",
               "languages/wasm-browser"
             ]

--- a/languages/c.mdx
+++ b/languages/c.mdx
@@ -1,0 +1,85 @@
+---
+title: "C"
+description: "Use iroh from C via the iroh-c-ffi bindings."
+---
+
+| Platform | Architectures |
+| --- | --- |
+| Linux | x86_64 (glibc) |
+| macOS | arm64 |
+| Windows | x86_64 |
+
+- **Header:** [`irohnet.h`](https://github.com/n0-computer/iroh-c-ffi/blob/main/irohnet.h), checked into the repo
+- **Examples:** [main.c](https://github.com/n0-computer/iroh-c-ffi/blob/main/main.c) and the [multi-thread examples](https://github.com/n0-computer/iroh-c-ffi/tree/main)
+- **All languages:** [platform support matrix](/languages#platform-support)
+
+[`iroh-c-ffi`](https://github.com/n0-computer/iroh-c-ffi) is a raw C API generated with [safer-ffi](https://github.com/getditto/safer-ffi) — unlike the Python, Swift, Kotlin, and JavaScript bindings, it isn't built on `iroh-ffi`/uniffi. There are no prebuilt binaries; you build the static/shared library from source and link against it.
+
+## Install
+
+```bash
+git clone https://github.com/n0-computer/iroh-c-ffi
+cd iroh-c-ffi
+cargo build --release
+```
+
+This produces `target/release/libiroh_c_ffi.{a,so,dylib}`. The matching header is already checked in as `irohnet.h`; regenerate it only if you're tracking an API change:
+
+```bash
+cargo run --features headers --bin generate_headers --release
+```
+
+## Hello, iroh
+
+```c
+#include <stdio.h>
+#include <string.h>
+#include "irohnet.h"
+
+int main(void) {
+  char alpn[] = "hello-c-ffi/0";
+  slice_ref_uint8_t alpn_slice;
+  alpn_slice.ptr = (uint8_t *) alpn;
+  alpn_slice.len = strlen(alpn);
+
+  EndpointConfig_t config = endpoint_config_default();
+  endpoint_config_add_alpn(&config, alpn_slice);
+
+  Endpoint_t *ep = endpoint_default();
+  if (endpoint_bind(&config, NULL, NULL, &ep) != 0) {
+    fprintf(stderr, "failed to bind\n");
+    return 1;
+  }
+  endpoint_online(&ep, 5000);
+
+  EndpointAddr_t addr = endpoint_addr_default();
+  endpoint_addr(&ep, &addr);
+  printf("endpoint id: %s\n", public_key_as_base32(&addr.id));
+
+  endpoint_free(ep);
+  endpoint_config_free(config);
+  return 0;
+}
+```
+
+Build and link against the library from the previous step:
+
+```bash
+cc -o hello hello.c -L target/release -liroh_c_ffi -lm
+```
+
+This binds an endpoint with a single ALPN, waits up to 5 seconds for a home relay, and prints the endpoint id. See the [CI workflow](https://github.com/n0-computer/iroh-c-ffi/blob/main/.github/workflows/ci.yml) for the extra link flags Windows needs.
+
+## Next steps
+
+<Card title="main.c example" icon="rocket" href="https://github.com/n0-computer/iroh-c-ffi/blob/main/main.c" horizontal>
+  A full server/client pair: bind, accept, send, and receive over uni- and bi-directional streams.
+</Card>
+
+<Card title="Multi-threaded examples" icon="server" href="https://github.com/n0-computer/iroh-c-ffi/tree/main" horizontal>
+  `multi-thread-server.c`, `multi-thread-client.c`, and `single-thread-server.c` for handling concurrent connections.
+</Card>
+
+<Card title="iroh-c-ffi repository" icon="github" href="https://github.com/n0-computer/iroh-c-ffi" horizontal>
+  Source, generated header, and issue tracker for the C bindings.
+</Card>

--- a/languages/index.mdx
+++ b/languages/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Overview"
-description: "Use iroh from Rust, Python, Swift, Kotlin, JavaScript or Go."
+description: "Use iroh from Rust, Python, Swift, Kotlin, JavaScript, C, or Go."
 ---
 
-iroh is available in Rust, Python, Swift, Kotlin, JavaScript, and Go. Pick the language that fits your app and follow its guide to get a working endpoint in minutes.
+iroh is available in Rust, Python, Swift, Kotlin, JavaScript, C, and Go. Pick the language that fits your app and follow its guide to get a working endpoint in minutes.
 
 | Language | Status | Platform notes |
 | --- | --- | --- |
@@ -12,6 +12,7 @@ iroh is available in Rust, Python, Swift, Kotlin, JavaScript, and Go. Pick the l
 | [Swift](/languages/swift) | Official | iOS + macOS |
 | [Kotlin](/languages/kotlin) | Official | JVM + Android |
 | [JavaScript](/languages/javascript) | Official | Node.js via N-API |
+| [C](/languages/c) | Official | Raw FFI via [iroh-c-ffi](https://github.com/n0-computer/iroh-c-ffi), build from source |
 | [Go](/languages/go) | Community | FFI bindings via [iroh-ffi](https://github.com/n0-computer/iroh-ffi) |
 
 "Community" bindings are built and maintained by community members rather than
@@ -19,7 +20,7 @@ the number0 team. They aren't covered by official support, may lag behind
 iroh releases, and cover fewer platforms — check each binding's page for
 current status before depending on it.
 
-All five official bindings share the same basic API surface for sending streams
+All six official bindings share the same basic API surface for sending streams
 or datagrams over QUIC.  The Rust language bindings are the most complete and
 up-to-date, and contain custom configuration and protocol features. 
 
@@ -31,19 +32,19 @@ up-to-date, and contain custom configuration and protocol features.
 
 The [n0.computer](https://n0.computer) team offers official support for the following platforms.
 
-| Platform                  | Rust | Python | Swift | Kotlin | JavaScript | Go |
-| ---                       | ---  | ---    | ---   | ---    | ---        | -- |
-| iOS (device + sim)        | ✓    | —      | ✓     | —      | —          | -  |
-| Android (aarch64, armv7)  | ✓    | —      | —     | ✓      | ✓          | -  |
-| macOS arm64               | ✓    | ✓      | ✓     | ✓      | ✓          | -  |
-| macOS x86_64              | ✓    | ✓      | ✗     | ✓      | ✗          | -  |
-| Linux x86_64 (glibc)      | ✓    | ✓      | —     | ✓      | ✓          | -  |
-| Linux x86_64 (musl)       | ✓    | ✗      | —     | ✗      | ✓          | ✓  |
-| Linux aarch64 (glibc)     | ✓    | ✓      | —     | ✓      | ✓          | -  |
-| Linux aarch64 (musl)      | ✓    | ✗      | —     | ✗      | ✓          | ✓  |
-| Linux armv7               | ✓    | ✗      | —     | ✗      | ✓          | -  |
-| Windows x86_64            | ✓    | ✓      | —     | ✓      | ✓          | -  |
-| Windows aarch64           | ✓    | ✗      | —     | ✗      | ✓          | -  |
+| Platform                  | Rust | Python | Swift | Kotlin | JavaScript | C | Go |
+| ---                       | ---  | ---    | ---   | ---    | ---        | - | -- |
+| iOS (device + sim)        | ✓    | —      | ✓     | —      | —          | ✗ | -  |
+| Android (aarch64, armv7)  | ✓    | —      | —     | ✓      | ✓          | ✗ | -  |
+| macOS arm64               | ✓    | ✓      | ✓     | ✓      | ✓          | ✓ | -  |
+| macOS x86_64              | ✓    | ✓      | ✗     | ✓      | ✗          | ✗ | -  |
+| Linux x86_64 (glibc)      | ✓    | ✓      | —     | ✓      | ✓          | ✓ | -  |
+| Linux x86_64 (musl)       | ✓    | ✗      | —     | ✗      | ✓          | ✗ | ✓  |
+| Linux aarch64 (glibc)     | ✓    | ✓      | —     | ✓      | ✓          | ✗ | -  |
+| Linux aarch64 (musl)      | ✓    | ✗      | —     | ✗      | ✓          | ✗ | ✓  |
+| Linux armv7               | ✓    | ✗      | —     | ✗      | ✓          | ✗ | -  |
+| Windows x86_64            | ✓    | ✓      | —     | ✓      | ✓          | ✓ | -  |
+| Windows aarch64           | ✓    | ✗      | —     | ✗      | ✓          | ✗ | -  |
 
 <Card title="Need a language we don't support?" icon="envelope" href="https://cal.com/team/number-0/iroh-services" horizontal>
   Get in touch and tell us what you're building. We can prioritize new bindings or help you maintain your own.


### PR DESCRIPTION
## Summary
- Add `languages/c.mdx` covering the raw C API from [iroh-c-ffi](https://github.com/n0-computer/iroh-c-ffi): install/build from source, a hello-world example, and links to the fuller examples in the repo
- Wire it into `docs.json` nav and `languages/index.mdx` (overview table, intro line, platform support matrix)
- Add a short note explaining what "Community" status means for bindings like Go

## Platform support matrix
Verified against `iroh-c-ffi`'s CI (`ci.yml`): full build+run tests cover Linux x86_64 (glibc), macOS arm64, and Windows x86_64. Android (aarch64/armv7) has a cross-compile-only job with no link/execution test, so it's marked unsupported — a lower bar than Kotlin's Android row, which is backed by an actual emulator smoke test in `iroh-ffi`'s CI.

## Test plan
- [ ] Preview the `/languages/c` page and platform support table render correctly