### PR TITLE
docs(add-a-relay): show relay config in all five languages

### DIFF
--- a/snippets/relay-preset-config.mdx
+++ b/snippets/relay-preset-config.mdx
@@ -9,8 +9,8 @@ In Rust, add the `iroh-services` crate to your project:
 cargo add iroh-services
 ```
 
-The Python, Swift, and Kotlin bindings ship the preset as part of `iroh-ffi`,
-with no extra dependency needed.
+The Python, Swift, Kotlin, and JavaScript bindings ship the preset as part of
+`iroh-ffi`, with no extra dependency needed.
 
 <CodeGroup>
 
@@ -102,7 +102,29 @@ fun main() = runBlocking {
 }
 ```
 
+```javascript JavaScript
+import { Endpoint, presetIrohServices } from '@number0/iroh'
+
+// Apply a preset pointing at your dedicated relays, authenticated with your
+// project's API key. In production, load the key from a config file or
+// environment variable instead of hardcoding it.
+const builder = Endpoint.builder()
+presetIrohServices(builder, {
+  relays: ['YOUR_RELAY_URL_US', 'YOUR_RELAY_URL_EU'],
+  apiSecret: 'YOUR_API_KEY',
+})
+
+// Bind the endpoint, then wait until it's online to confirm it has an
+// authorized connection to a relay.
+const ep = await builder.bind()
+await ep.online()
+```
+
 </CodeGroup>
+
+In JavaScript, presets are functions applied to an `EndpointBuilder`, so use
+`Endpoint.builder()` rather than `Endpoint.bind()` — `bind()` always applies the
+n0 preset.
 
 <Note>
   Custom relay URLs are available on Pro and Enterprise projects, or if you self-host your own relay.

--- a/snippets/relay-preset-config.mdx
+++ b/snippets/relay-preset-config.mdx
@@ -130,4 +130,4 @@ n0 preset.
   Custom relay URLs are available on Pro and Enterprise projects, or if you self-host your own relay.
 </Note>
 
-On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) — in Rust you can also pass your API key to `iroh_services::preset()` without `relays(...)` to authenticate against the public relays and surface your relay traffic on the dashboard.
+On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) instead.

--- a/snippets/relay-preset-config.mdx
+++ b/snippets/relay-preset-config.mdx
@@ -105,13 +105,7 @@ fun main() = runBlocking {
 </CodeGroup>
 
 <Note>
-  Custom relay URLs are available on Pro and Enterprise projects. On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) — in Rust you can also pass your API key to `iroh_services::preset()` without `relays(...)` to authenticate against the public relays and surface your relay traffic on the dashboard.
+  Custom relay URLs are available on Pro and Enterprise projects, or if you self-host your own relay.
 </Note>
 
-The access token is minted when you build the preset, and is scoped to the
-endpoint's key. Both are handled for you if you let the preset generate the key.
-To pin your endpoint's identity instead, pass your saved key to the preset —
-in the bindings that's `ServicesPresetOptions.secretKey`, not
-`EndpointOptions.secretKey`. Option fields are layered on top of the preset, so
-a key set there replaces the one the token is scoped to and the relays will
-reject the endpoint.
+On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) — in Rust you can also pass your API key to `iroh_services::preset()` without `relays(...)` to authenticate against the public relays and surface your relay traffic on the dashboard.

--- a/snippets/relay-preset-config.mdx
+++ b/snippets/relay-preset-config.mdx
@@ -130,4 +130,4 @@ n0 preset.
   Custom relay URLs are available on Pro and Enterprise projects, or if you self-host your own relay.
 </Note>
 
-On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) instead.
+On a free project, omit the relay URLs — the preset then authenticates against the n0 public relays.

--- a/snippets/relay-preset-config.mdx
+++ b/snippets/relay-preset-config.mdx
@@ -1,17 +1,20 @@
-Your dedicated relays require authentication by default. Your endpoint
-authenticates to them with your project's API key. The `iroh_services::preset()` builder handles
-this for you: it mints a short-lived access token scoped to your endpoint's key
-and configures the endpoint to use your relays.
+Your dedicated relays require authentication. Your endpoint authenticates to
+them with your project's API key: the iroh-services preset mints a short-lived
+access token scoped to your endpoint's key and to relay use only, then
+configures the endpoint to use your relays.
 
-Add the `iroh-services` crate to your project:
+In Rust, add the `iroh-services` crate to your project:
 
 ```bash
 cargo add iroh-services
 ```
 
-Then build a preset and bind your endpoint with it:
+The Python, Swift, and Kotlin bindings ship the preset as part of `iroh-ffi`,
+with no extra dependency needed.
 
-```rust
+<CodeGroup>
+
+```rust Rust
 use iroh::Endpoint;
 
 #[tokio::main]
@@ -36,6 +39,79 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
+```python Python
+import asyncio
+import iroh
+
+async def main():
+    # Build a preset pointing at your dedicated relays, authenticated with
+    # your project's API key. In production, load the key from a config file
+    # or environment variable instead of hardcoding it.
+    preset = iroh.preset_iroh_services(
+        iroh.ServicesPresetOptions(
+            relays=["YOUR_RELAY_URL_US", "YOUR_RELAY_URL_EU"],
+            api_secret="YOUR_API_KEY",
+        )
+    )
+
+    # Bind the endpoint with the preset, then wait until it's online to
+    # confirm it has an authorized connection to a relay.
+    ep = await iroh.Endpoint.bind(iroh.EndpointOptions(preset=preset))
+    await ep.online()
+
+asyncio.run(main())
+```
+
+```swift Swift
+import IrohLib
+
+// Build a preset pointing at your dedicated relays, authenticated with your
+// project's API key. In production, load the key from a config file or
+// environment variable instead of hardcoding it.
+let preset = try presetIrohServices(options: ServicesPresetOptions(
+    relays: ["YOUR_RELAY_URL_US", "YOUR_RELAY_URL_EU"],
+    apiSecret: "YOUR_API_KEY"
+))
+
+// Bind the endpoint with the preset, then wait until it's online to confirm
+// it has an authorized connection to a relay.
+let ep = try await Endpoint.bind(options: EndpointOptions(preset: preset))
+await ep.online()
+```
+
+```kotlin Kotlin
+import computer.iroh.*
+import kotlinx.coroutines.runBlocking
+
+fun main() = runBlocking {
+    // Build a preset pointing at your dedicated relays, authenticated with
+    // your project's API key. In production, load the key from a config file
+    // or environment variable instead of hardcoding it.
+    val preset = presetIrohServices(
+        ServicesPresetOptions(
+            relays = listOf("YOUR_RELAY_URL_US", "YOUR_RELAY_URL_EU"),
+            apiSecret = "YOUR_API_KEY",
+        ),
+    )
+
+    // Bind the endpoint with the preset, then wait until it's online to
+    // confirm it has an authorized connection to a relay.
+    val ep = Endpoint.bind(EndpointOptions(preset = preset))
+    ep.online()
+    ep.shutdown()
+}
+```
+
+</CodeGroup>
+
 <Note>
-  Custom relay URLs are available on Pro and Enterprise projects. On a free project, pass your API key to the preset without `relays(...)` to authenticate against the public relays and surface your relay traffic on the dashboard.
+  Custom relay URLs are available on Pro and Enterprise projects. On a free project, use the n0 preset (`presets::N0`, `preset_n0()`) — in Rust you can also pass your API key to `iroh_services::preset()` without `relays(...)` to authenticate against the public relays and surface your relay traffic on the dashboard.
 </Note>
+
+The access token is minted when you build the preset, and is scoped to the
+endpoint's key. Both are handled for you if you let the preset generate the key.
+To pin your endpoint's identity instead, pass your saved key to the preset —
+in the bindings that's `ServicesPresetOptions.secretKey`, not
+`EndpointOptions.secretKey`. Option fields are layered on top of the preset, so
+a key set there replaces the one the token is scoped to and the relays will
+reject the endpoint.


### PR DESCRIPTION
## What

`snippets/relay-preset-config.mdx` (rendered on [/add-a-relay](https://docs.iroh.computer/add-a-relay)) was Rust-only. It's now a five-language `CodeGroup` — Rust, Python, Swift, Kotlin, JavaScript — with every example authenticated via the iroh-services preset.

## Why authenticated everywhere

Dedicated relays reject an endpoint that doesn't present a relay-scoped access token. A `RelayMode.customFromUrls(...)` example sets no token, so it would look right and fail to connect.

## JavaScript is shaped differently

In JS a preset is a function applied to an `EndpointBuilder`, not a value passed to `bind()` — and `Endpoint.bind()` always applies the n0 preset. So that tab uses `Endpoint.builder()`, with a one-line note explaining why it differs from the others.

## Free-tier line

The closing line said this was a Rust-only trick, which it was. iroh-ffi#284 makes the bindings fall back to the n0 relays like Rust, so omitting the relay URLs is now the free-project path in every language — one sentence, no second preset to explain.

## Blocked on

n0-computer/iroh-ffi#284 adds `preset_iroh_services` to the Python, Swift, Kotlin, and JavaScript bindings. **Don't merge this before that ships in an iroh-ffi release** — until then those four snippets document an API users can't install. The Rust snippet is unchanged and correct today.

## Verification

Every non-Rust signature was checked against generated bindings rather than written from memory — uniffi bindgen run for Python/Swift/Kotlin, `napi build` for the JS `index.d.ts`, plus the Rust, Python, and JS tests in iroh-ffi#284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)