### PR TITLE
docs(Blobs): Fix endpoint address usage in download function

### DIFF
--- a/protocols/blobs.mdx
+++ b/protocols/blobs.mdx
@@ -272,7 +272,7 @@ let downloader = store.downloader(&endpoint);
 println!("Starting download.");
 
 downloader
-    .download(ticket.hash(), Some(ticket.endpoint_addr().id)
+    .download(ticket.hash(), Some(ticket.addr().id)
     .await?;
 
 println!("Finished download.");


### PR DESCRIPTION
This will align the function name that is in the current example (https://github.com/n0-computer/iroh-blobs/blob/main/examples/transfer.rs) with the docs